### PR TITLE
fix regex

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -45,7 +45,7 @@ runs:
           exit 1
         fi
 
-        if ! echo "${{ inputs.test_plan_id }}" | grep -Eq '^[0-9]+$'; then
+        if ! echo "${{ inputs.test_plan_id }}" | grep -E '^[0-9]+$'; then
           error "Test Plan ID should be string of digits"
           exit 1
         fi


### PR DESCRIPTION
- it doesn't work on ubuntu. (no output)
```
$ ID=1234
$ echo $ID | grep -Eq '^[0-9]+$'

```

- it works on ubuntu.
```
$ ID=1234
$ echo $ID | grep -E '^[0-9]+$'
1234
```